### PR TITLE
Recompile with Tapestry 5.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 .settings/
 /build/**
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
 			</plugin>
 
 			<plugin>
-				<groupId>com.mycila.maven-license-plugin</groupId>
-				<artifactId>maven-license-plugin</artifactId>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
 					<header>LICENSE.txt</header>
@@ -318,7 +318,7 @@
 			<id>central</id>
 			<name>Maven Repository</name>
 			<layout>default</layout>
-			<url>http://central.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -327,12 +327,12 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>maven</id>
-			<url>http://central.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 	</pluginRepositories>
 	<profiles>
@@ -362,7 +362,7 @@
 	</profiles>
 
 	<properties>
-		<tapestry-release-version>5.4.1</tapestry-release-version>
+		<tapestry-release-version>5.6.3</tapestry-release-version>
 		<selenium-version>2.35.0</selenium-version>
 		<browserStartCommand>*googlechrome</browserStartCommand>
 		<sourceDirectory>src/main/java</sourceDirectory>

--- a/src/main/java/org/got5/tapestry5/upload/components/AjaxUpload.java
+++ b/src/main/java/org/got5/tapestry5/upload/components/AjaxUpload.java
@@ -238,7 +238,7 @@ public class AjaxUpload implements ClientElement {
 
             final Object overrideChild = overrides.get(key);
 
-            if (defaults.has(key)) {
+            if (defaults.containsKey(key)) {
 
                 final Object defaultChild = defaults.get(key);
 


### PR DESCRIPTION
Existing distribution cannot be used with 5.6.2+ as JSONObject binary compatibility was broken in https://issues.apache.org/jira/browse/TAP5-2640